### PR TITLE
H3 Index 조회 시 row_number() Window Function을 사용하도록 설정한 PR 올립니다.

### DIFF
--- a/src/main/java/back/neonadeuli/config/QueryDslConfig.java
+++ b/src/main/java/back/neonadeuli/config/QueryDslConfig.java
@@ -1,19 +1,23 @@
 package back.neonadeuli.config;
 
+import com.querydsl.jpa.Hibernate5Templates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.sql.SQLOps;
 import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@RequiredArgsConstructor
 public class QueryDslConfig {
 
-    private final EntityManager entityManager;
-
     @Bean
-    public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(new CustomTemplates(), entityManager);
+    }
+
+    private static class CustomTemplates extends Hibernate5Templates {
+        public CustomTemplates() {
+            add(SQLOps.ROWNUMBER, "row_number()");
+        }
     }
 }

--- a/src/main/java/back/neonadeuli/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/back/neonadeuli/post/repository/PostRepositoryImpl.java
@@ -40,8 +40,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         EnumMap<Resolution, Supplier<NumberPath<Long>>> resolutionFunctions =
                 new EnumMap<>(Resolution.class);
 
-        resolutionFunctions.put(Resolution.RES_6, this::res6Path);
-        resolutionFunctions.put(Resolution.RES_4, this::res4Path);
+        resolutionFunctions.put(Resolution.RES_6, () -> location.h3Res6);
+        resolutionFunctions.put(Resolution.RES_4, () -> location.h3Res4);
 
         return resolutionFunctions;
     }
@@ -109,14 +109,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 SQLExpressions.rowNumber().over().partitionBy(resPath));
 
         return retrievePosts(accountDetail, pageable, resPath.in(h3Indexes), orderSpecifier);
-    }
-
-    private NumberPath<Long> res4Path() {
-        return location.h3Res4;
-    }
-
-    private NumberPath<Long> res6Path() {
-        return location.h3Res6;
     }
 
     private static BooleanExpression accountPrivatePost(AccountDetail accountDetail) {

--- a/src/main/java/back/neonadeuli/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/back/neonadeuli/post/repository/PostRepositoryImpl.java
@@ -12,31 +12,36 @@ import back.neonadeuli.location.model.Resolution;
 import back.neonadeuli.post.dto.response.PostResponseDto;
 import back.neonadeuli.post.dto.response.QPostResponseDto;
 import back.neonadeuli.post.entity.Visibility;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.spatial.locationtech.jts.JTSGeometryExpressions;
+import com.querydsl.sql.SQLExpressions;
 import com.uber.h3core.util.LatLng;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
 @RequiredArgsConstructor
 public class PostRepositoryImpl implements PostRepositoryCustom {
 
-    private final Map<Resolution, Function<List<Long>, BooleanExpression>> resolutionExpressions =
-            createResolutionFunctions();
+    private final Map<Resolution, Supplier<NumberPath<Long>>> resolutionPaths =
+            createResolutionPathSupplier();
 
-    private Map<Resolution, Function<List<Long>, BooleanExpression>> createResolutionFunctions() {
+    private Map<Resolution, Supplier<NumberPath<Long>>> createResolutionPathSupplier() {
 
-        EnumMap<Resolution, Function<List<Long>, BooleanExpression>> resolutionFunctions =
+        EnumMap<Resolution, Supplier<NumberPath<Long>>> resolutionFunctions =
                 new EnumMap<>(Resolution.class);
 
-        resolutionFunctions.put(Resolution.RES_6, this::res6Expression);
-        resolutionFunctions.put(Resolution.RES_4, this::res4Expression);
+        resolutionFunctions.put(Resolution.RES_6, this::res6Path);
+        resolutionFunctions.put(Resolution.RES_4, this::res4Path);
 
         return resolutionFunctions;
     }
@@ -49,14 +54,18 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                                GeometryDistance geometryDistance,
                                                Pageable pageable) {
 
-        return retrievePosts(accountDetail, pageable,
-                JTSGeometryExpressions.asJTSGeometry(locationSupplier.newPoint(latLng.lat, latLng.lng))
-                        .buffer(geometryDistance.distance())
-                        .contains(location.point));
+        BooleanExpression contains = JTSGeometryExpressions.asJTSGeometry(
+                        locationSupplier.newPoint(latLng.lat, latLng.lng))
+                .buffer(geometryDistance.distance())
+                .contains(location.point);
+
+        OrderSpecifier<Comparable<?>> notOrder = new OrderSpecifier<>(Order.ASC, Expressions.nullExpression());
+
+        return retrievePosts(accountDetail, pageable, contains, notOrder);
     }
 
     private List<PostResponseDto> retrievePosts(AccountDetail accountDetail, Pageable pageable,
-                                                BooleanExpression expression) {
+                                                BooleanExpression locationFilter, OrderSpecifier<?> specifier) {
 
         return queryFactory
 
@@ -74,11 +83,13 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .innerJoin(account.picture, picture)
                 .innerJoin(post.location, location)
 
-                .where(expression,
+                .where(locationFilter,
                         post.locationAvailable.isTrue(),
                         post.visibility.eq(Visibility.PUBLIC)
                                 .or(accountPrivatePost(accountDetail))
                 )
+
+                .orderBy(specifier)
 
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -89,19 +100,23 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     @Override
     public List<PostResponseDto> retrievePosts(AccountDetail accountDetail, Resolution resolution, List<Long> h3Indexes,
                                                Pageable pageable) {
-        BooleanExpression expression = resolutionExpressions.getOrDefault(resolution, ignore -> {
+
+        NumberPath<Long> resPath = resolutionPaths.getOrDefault(resolution, () -> {
             throw new IllegalStateException();
-        }).apply(h3Indexes);
+        }).get();
 
-        return retrievePosts(accountDetail, pageable, expression);
+        OrderSpecifier<Long> orderSpecifier = new OrderSpecifier<>(Order.DESC,
+                SQLExpressions.rowNumber().over().partitionBy(resPath));
+
+        return retrievePosts(accountDetail, pageable, resPath.in(h3Indexes), orderSpecifier);
     }
 
-    private BooleanExpression res4Expression(List<Long> h3Res4Indexes) {
-        return location.h3Res4.in(h3Res4Indexes);
+    private NumberPath<Long> res4Path() {
+        return location.h3Res4;
     }
 
-    private BooleanExpression res6Expression(List<Long> h3Res6Indexes) {
-        return location.h3Res6.in(h3Res6Indexes);
+    private NumberPath<Long> res6Path() {
+        return location.h3Res6;
     }
 
     private static BooleanExpression accountPrivatePost(AccountDetail accountDetail) {


### PR DESCRIPTION
- Geometry 조회와 H3 조회는 몇몇 조건을 제외하고 겹치는 부분이 상당히 많습니다. 따라서 코드 중복을 최소화 했습니다.
- 조회 조건, 정렬 조건 등의 설정은 동적 쿼리 및 파라미터로 해결하였습니다.
- spatial 연산, row_number() 연산을 위해 Hibernate5Templates를 상속한 CustomTemplates를 사용하였습니다.
  - spatial 연산은 Hibernate5Templates 내에 자동으로 기입됩니다.
  - row_number() 연산은 CustomTemplates에서 사용할 수 있도록 따로 add 합니다.